### PR TITLE
feat: add resnet18 preprocessing

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -154,6 +154,7 @@ def parse_arguments():
     argparser.add_argument(
         '--perceiver-img-pre-type',
         type=str,
+        choices=['cnn', 'resnet18', 'dino'],
         default='cnn',
         help="Perceiver image preprocess model"
     )


### PR DESCRIPTION
Add resnet18 for frame feature extraction before feeding it into perceiver model.

References:
* https://arxiv.org/pdf/1512.03385
* https://pytorch.org/tutorials/intermediate/quantized_transfer_learning_tutorial.html#part-1-training-a-custom-classifier-based-on-a-quantized-feature-extractor